### PR TITLE
修复历史长文轮次prompt重复的bug

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -192,7 +192,7 @@ class NN_DataHelper(DataHelper):
                             if j == sid:
                                 prompt_text += "[Round {}]\n问：{}\n答：".format(sid, paragraph[j][0])
                             else:
-                                prompt_text += "[Round {}]\n问：{}\n答：{}".format(sid, paragraph[j][0], paragraph[j][1])
+                                prompt_text += "[Round {}]\n问：{}\n答：{}".format(j, paragraph[j][0], paragraph[j][1])
                         D.append((prompt_text,a))
         return D
 


### PR DESCRIPTION
现在是：
上文
[Round 2] 问：你好 答：嗯你好 
[Round 2] 问：天气如何 答：不错 
[Round 2] 问：吃了么 答：
标签：吃了

修复为

上文
[Round 0]问：你好 答：嗯你好 
[Round 1] 问：天气如何 答：不错 
[Round 2] 问：吃了么 答：
标签：吃了